### PR TITLE
Fix 4734: Normalize contextPath handling in bitstream download route

### DIFF
--- a/src/app/app-routing-paths.ts
+++ b/src/app/app-routing-paths.ts
@@ -1,3 +1,4 @@
+import { environment } from 'src/environments/environment';
 import { getCollectionPageRoute } from './collection-page/collection-page-routing-paths';
 import { getCommunityPageRoute } from './community-page/community-page-routing-paths';
 import { Collection } from './core/shared/collection.model';
@@ -22,8 +23,31 @@ export function getBitstreamModuleRoute() {
   return `/${BITSTREAM_MODULE_PATH}`;
 }
 
+/**
+ * Normalizes the application's contextPath:
+ * - Returns "" if it is "/" or empty.
+ * - Ensures it starts with "/" if missing.
+ * - Removes trailing "/" if present.
+ */
+export function normalizeContextPath(contextPath?: string): string {
+  if (!contextPath || contextPath === "/") {
+    return "";
+  }
+
+  let path = contextPath.trim();
+
+  if (!path.startsWith("/")) {
+    path = "/" + path;
+  }
+  if (path.endsWith("/")) {
+    path = path.slice(0, -1);
+  }
+  return path;
+}
+
 export function getBitstreamDownloadRoute(bitstream): string {
-  return new URLCombiner(getBitstreamModuleRoute(), bitstream.uuid, 'download').toString();
+  const contextPath = normalizeContextPath(environment.ui.nameSpace);
+  return new URLCombiner(contextPath+getBitstreamModuleRoute(), bitstream.uuid, 'download').toString();
 }
 export function getBitstreamRequestACopyRoute(item, bitstream): { routerLink: string, queryParams: any } {
   const url = new URLCombiner(getItemModuleRoute(), item.uuid, 'request-a-copy').toString();

--- a/src/app/app-routing-paths.ts
+++ b/src/app/app-routing-paths.ts
@@ -1,4 +1,5 @@
 import { environment } from 'src/environments/environment';
+
 import { getCollectionPageRoute } from './collection-page/collection-page-routing-paths';
 import { getCommunityPageRoute } from './community-page/community-page-routing-paths';
 import { Collection } from './core/shared/collection.model';
@@ -30,16 +31,16 @@ export function getBitstreamModuleRoute() {
  * - Removes trailing "/" if present.
  */
 export function normalizeContextPath(contextPath?: string): string {
-  if (!contextPath || contextPath === "/") {
-    return "";
+  if (!contextPath || contextPath === '/') {
+    return '';
   }
 
   let path = contextPath.trim();
 
-  if (!path.startsWith("/")) {
-    path = "/" + path;
+  if (!path.startsWith('/')) {
+    path = '/' + path;
   }
-  if (path.endsWith("/")) {
+  if (path.endsWith('/')) {
     path = path.slice(0, -1);
   }
   return path;
@@ -47,7 +48,7 @@ export function normalizeContextPath(contextPath?: string): string {
 
 export function getBitstreamDownloadRoute(bitstream): string {
   const contextPath = normalizeContextPath(environment.ui.nameSpace);
-  return new URLCombiner(contextPath+getBitstreamModuleRoute(), bitstream.uuid, 'download').toString();
+  return new URLCombiner(contextPath + getBitstreamModuleRoute(), bitstream.uuid, 'download').toString();
 }
 export function getBitstreamRequestACopyRoute(item, bitstream): { routerLink: string, queryParams: any } {
   const url = new URLCombiner(getItemModuleRoute(), item.uuid, 'request-a-copy').toString();


### PR DESCRIPTION
## References
* Fixes #4734

## Description
This PR fixes the generation of bitstream download URLs when DSpace Angular
is deployed under a custom context path (e.g. `/repository`).  
Previously, the `environment.ui.nameSpace` was ignored, resulting in broken download links (`404 Not Found`).

## Instructions for Reviewers
List of changes in this PR:
* Normalize `environment.ui.nameSpace` before building the download route
* Ensure `/` is omitted but custom paths (e.g. `/repository`) are correctly prepended
* Prevent generation of double slashes in URLs

### How to test
1. Deploy DSpace Angular under a custom context path, e.g. `http://localhost:4000/repository`.
2. As an administrator, edit an Item and go to the **Edit Item** screen.
3. Select the **Files** tab.
4. In the **BUNDLE: ORIGINAL, TEXT, THUMBNAIL, LICENSE** section, click the download icon in the **Actions** column.
5. Observe the generated download URL:
   * **Expected**: `http://localhost:4000/repository/bitstreams/<uuid>/download`
   * **Actual before fix**: `http://localhost:4000/bitstreams/<uuid>/download` → results in `404 Not Found`.
6. Verify that download links now work correctly under both root (`/`) and subpath deployments.

## Checklist
- [x] My PR is **created against the `main` branch** of code.
- [x] My PR is **small in size** and focused on a single fix.
- [x] My PR **passes [ESLint](https://eslint.org/)** validation using `npm run lint`.
- [x] My PR **doesn't introduce circular dependencies** (`npm run check-circ-deps`).
- [x] My PR includes clear instructions for testing this fix.
- [x] This fix has been verified on **DSpace Angular 7.4** and **9.1**.
